### PR TITLE
Change use of deprecated Dict to Keyword in Http

### DIFF
--- a/lib/segment/analytics.ex
+++ b/lib/segment/analytics.ex
@@ -80,7 +80,7 @@ defmodule Segment.Analytics do
 
   defp post_to_segment(function, body) do
     Http.post(function, body)
-      |> log_result(function, body)
+    |> log_result(function, body)
   end
 
   defp log_result({_, %{status_code: code}}, function, body) when code in 200..299 do

--- a/lib/segment/http.ex
+++ b/lib/segment/http.ex
@@ -4,20 +4,23 @@ defmodule Segment.Analytics.Http do
   @base_url "https://api.segment.io/v1/"
 
   def process_url(url) do
-      @base_url <> url
+    @base_url <> url
   end
 
   def post(url, body, headers, options \\ []) do
-    options_with_auth = Keyword.merge(options, [hackney: [basic_auth: {Segment.write_key, ""}]])
+    options_with_auth =
+      Keyword.merge(options, [hackney: [basic_auth: {Segment.write_key(), ""}]])
+
     request(:post, url, body, headers, options_with_auth)
   end
 
   def process_options(options) do
-    Dict.put(options, :basic_auth, {Segment.write_key(),""})
+    Keyword.put(options, :basic_auth, {Segment.write_key(),""})
   end
 
   def process_request_headers(headers) do
-      Dict.put(headers, :"Content-Type", "application/json")
-      |> Dict.put(:"accept", "application/json")
+    headers
+    |> Keyword.put(:"Content-Type", "application/json")
+    |> Keyword.put(:"accept", "application/json")
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AnalyticsElixir.Mixfile do
   def project do
     [
       app: :segment,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.0",
       deps: deps(),
       description: "analytics_elixir",


### PR DESCRIPTION
Needed to avoid compile warnings on newer Elixir
versions.

Tidy some spacing + line length.

Bump release to 0.1.2